### PR TITLE
close #10 각 채널의 채팅 로그 남기기 완료

### DIFF
--- a/src/main/java/com/springboot/boot/controller/ChatController.java
+++ b/src/main/java/com/springboot/boot/controller/ChatController.java
@@ -8,14 +8,16 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Controller
 public class ChatController {
 
     // 채널별로 메시지를 처리하도록 변경하고, 채널 정보를 포함한 메시지를 전송합니다.
     private final SimpMessagingTemplate messagingTemplate;
-    private List<ChatMessage> messages = new ArrayList<>();
+    private final Map<String, List<ChatMessage>> chatHistory = new HashMap<>();
 
     // SimpMessagingTemplate를 초기화 합니다.
     public ChatController(SimpMessagingTemplate messagingTemplate) {
@@ -25,7 +27,25 @@ public class ChatController {
     @MessageMapping("/message/{channel}")
     public void sendMessage(ChatMessage message, @DestinationVariable String channel) {
         if (!message.getText().trim().isEmpty()) {
+            message.setChannel(channel);
+            saveMessage(message);
             messagingTemplate.convertAndSend("/topic/messages/" + channel, message); 
         }
+    }
+
+    @MessageMapping("/history/{channel}")
+    public void sendChatHistory(@DestinationVariable String channel) {
+        List<ChatMessage> messages = chatHistory.getOrDefault(channel, new ArrayList<>());
+        messagingTemplate.convertAndSend("/topic/history/" + channel, messages);
+    }
+
+//    @MessageMapping("/joinChannel/{channel}")
+//    public void joinChannel(String username, @DestinationVariable String channel) {
+//        List<ChatMessage> messages = chatHistory.getOrDefault(channel, new ArrayList<>());
+//        messagingTemplate.convertAndSend("/topic/history/" + channel, messages);
+//    }
+
+    private void saveMessage(ChatMessage message) {
+        chatHistory.computeIfAbsent(message.getChannel(), k -> new ArrayList<>()).add(message);
     }
 }

--- a/src/main/resources/static/chat.html
+++ b/src/main/resources/static/chat.html
@@ -40,12 +40,16 @@
             stompClient.subscribe('/topic/users/' + channel, function (userOutput) {
                 updateUserList(JSON.parse(userOutput.body));
             });
+            stompClient.subscribe('/topic/history/' + channel, function(historyOutput) {
+                loadChatHistory(JSON.parse(historyOutput.body));
+            });
             joinChannel();
         });
     }
 
     function joinChannel() {
         stompClient.send("/app/joinChannel", {}, JSON.stringify({'username': username, 'channel': channel}));
+        stompClient.send("/app/history/" + channel, {});
     }
 
     function leaveChannel() {
@@ -67,6 +71,14 @@
             userElement.appendChild(document.createTextNode(user.username));
             userList.appendChild(userElement);
         });
+    }
+
+    function loadChatHistory(messages) {
+        var messageList = document.getElementById('messages');
+        messageList.innerHTML = '';
+        messages.forEach(function (message) {
+            showMessage(message);
+        })
     }
 
     document.getElementById('form').addEventListener('submit', function (e) {


### PR DESCRIPTION
ChatController: 채팅메시지와 채팅 기록을 관리합니다. 사용자가 채널에 입장할 때 채팅 기록을 전송합니다. 
ChannelController: 채널과 사용자 리스트를 관리합니다. 사용자가 채널에 입장하고 퇴장할 때 사용자 리스트를 업데이트합니다. 
chat.html 클라이언트에서채널에 입장할 때 채팅 기록과 사용자 리스트를 불러옵니다.